### PR TITLE
TracingRoundTripperでリクエストボディが出力されない問題を修正

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,7 +41,7 @@ var (
 	DefaultRetryMax = 10
 
 	// DefaultRetryWaitMin デフォルトのリトライ間隔(最小)
-	DefaultRetryWaitMin = 1 * time.Second 
+	DefaultRetryWaitMin = 1 * time.Second
 
 	// DefaultRetryWaitMax デフォルトのリトライ間隔(最大)
 	DefaultRetryWaitMax = 64 * time.Second

--- a/tracing_round_tripper_test.go
+++ b/tracing_round_tripper_test.go
@@ -63,7 +63,7 @@ func TestTracingRoundTripper_OutputOnlyError(t *testing.T) {
 				OutputOnlyError: tt.fields.OutputOnlyError,
 			}
 			client := &http.Client{Transport: r}
-			req, err := http.NewRequest("GET", server.URL, nil)
+			req, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("request body"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -77,7 +77,8 @@ func TestTracingRoundTripper_OutputOnlyError(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			require.Equal(t, tt.wantTraceLog, strings.Contains(logs.String(), "GET / HTTP/1.1"), "error log not found: request")
+			require.Equal(t, tt.wantTraceLog, strings.Contains(logs.String(), "POST / HTTP/1.1"), "error log not found: request")
+			require.Equal(t, tt.wantTraceLog, strings.Contains(logs.String(), "request body"), "error log not found: request body")
 			require.Equal(t, tt.wantTraceLog, strings.Contains(logs.String(), "HTTP/1.1 200 OK"), "error log not found: response")
 		})
 	}


### PR DESCRIPTION
httputil.DumpRequestを呼ぶ前にリクエストボディを読んでしまっていたためトレース出力されていなかった。
対応としてあらかじめボディを複製した上でボディを利用する各所で使い回すように修正

パフォーマンスは落ちるが、sacloud系ではHTTPリクエストのパフォーマンスはさほど求めていないため許容する。