### PR TITLE
actions/setup-go@v5でgo.modを利用する

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -22,10 +22,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
 
       - name: Setup tools
-        run: | 
+        run: |
           make tools
 
       - name: make test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
 
       - name: Setup tools
         run: |
@@ -38,10 +38,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
 
       - name: Setup tools
-        run: | 
+        run: |
           make tools
 
       - name: make lint-go
@@ -64,10 +64,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
 
       - name: Setup tools
-        run: | 
+        run: |
           make tools
 
       - name: make test


### PR DESCRIPTION
actions/setup-go@v5でgo.modを利用するようにしましたが、作業漏れがあったため追加で変更します。