### PR TITLE
golang @ 1.26

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-22.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-24.04, ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,31 @@
+version: "2"
 run:
-  deadline: 10m10s
+  timeout: 10m10s
 
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - exportloopref
     - gocritic
-    - gofmt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
     - nolintlint
-    - typecheck
     - unconvert
     - unused
     - whitespace
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
 
   # don't enable:
   #  - asciicheck

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ### 関連プロジェクト
 
 - [sacloud/api-client-go](https://github.com/sacloud/api-client-go): sacloudプロダクト向けHTTP/APIクライアントライブラリ
-  sacloud/go-httpをラップし環境変数やUsacloud互換のプロファイルの処理などを提供します。
+  sacloud/go-httpをラップし環境変数やUsacloud互換のプロファイルの処理などを提供する。
 
 
 ## License

--- a/client_test.go
+++ b/client_test.go
@@ -101,11 +101,12 @@ func TestClient_Do_CheckRetryWithContext(t *testing.T) {
 	})
 }
 
+//nolint:errcheck // this is only a test
 func TestClient_Do_withGzip(t *testing.T) {
 	var buf bytes.Buffer
 	writer := gzip.NewWriter(&buf)
 	io.WriteString(writer, "ok") //nolint //エラーは無視
-	writer.Close()
+	writer.Close()               // #nosec G104 -- this is only a test
 	gzipped := buf.Bytes()
 
 	dummyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/sacloud/go-http
 
-go 1.21
+go 1.25.0
+
+toolchain go1.26.2
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.7

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -42,7 +42,7 @@ dev-tools:
 	$(GO) install github.com/client9/misspell/cmd/misspell@latest
 	$(GO) install github.com/google/go-licenses@v1.0.0
 	$(GO) install github.com/rhysd/actionlint/cmd/actionlint@latest
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANG_CI_LINT_VERSION)
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANG_CI_LINT_VERSION)
 
 .PHONY: goimports
 goimports: fmt

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -19,8 +19,8 @@ COPYRIGHT_YEAR          ?= 2022
 COPYRIGHT_FILES         ?= $$(find . -name "*.go" -print | grep -v "/vendor/")
 GO                      ?= go
 DEFAULT_GOALS           ?= fmt set-license go-licenses-check goimports lint test
-GOLANG_CI_LINT_VERSION  ?= v1.59.1
-TEXTLINT_ACTION_VERSION ?= v0.0.3
+GOLANG_CI_LINT_VERSION  ?= v2.12.2
+TEXTLINT_ACTION_VERSION ?= v0.1.0
 
 .DEFAULT_GOAL = default
 

--- a/tracing_round_tripper.go
+++ b/tracing_round_tripper.go
@@ -33,6 +33,8 @@ type TracingRoundTripper struct {
 }
 
 // RoundTrip http.RoundTripperの実装
+//
+// #nosec G706 -- This is deprecated, just kept for theoretical backward compatibility.
 func (r *TracingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if r.Transport == nil {
 		r.Transport = http.DefaultTransport

--- a/tracing_round_tripper_test.go
+++ b/tracing_round_tripper_test.go
@@ -29,7 +29,7 @@ import (
 func TestTracingRoundTripper_OutputOnlyError(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "ok")
+		fmt.Fprintln(w, "ok") //nolint:errcheck // this is only a test
 	})
 	server := httptest.NewServer(h)
 


### PR DESCRIPTION
- https://github.com/sacloud/sacloud-sdk-go をやっていて出たgo-http側の差分です
  - 向こうで弄ってしまうと差分が出て大変めんどう
- 内容的にはgoのバージョンを上げたというところですが、なかなかの大きなジャンプになっていて不安かもしれませんが、実際にはこのライブラリに依存する他のものがすでに1.26で動作実績があるため、まあ大丈夫ですねというところです